### PR TITLE
Bug solved

### DIFF
--- a/app/src/main/java/it/units/borghisegreti/activities/MainActivity.java
+++ b/app/src/main/java/it/units/borghisegreti/activities/MainActivity.java
@@ -32,10 +32,17 @@ public class MainActivity extends AppCompatActivity {
         navController.addOnDestinationChangedListener(((controller, destination, arguments) -> {
             // here we can check the destination id and handle changes accordingly
             if (destination.getId() == R.id.mapsFragment) {
+                viewBinding.bottomNavigation.setVisibility(View.VISIBLE);
                 getWindow().addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
             } else if (destination.getId() == R.id.experiencesFragment) {
+                viewBinding.bottomNavigation.setVisibility(View.VISIBLE);
                 getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+            } else if (destination.getId() == R.id.loginFragment) {
+                viewBinding.bottomNavigation.setVisibility(View.GONE);
+            } else if (destination.getId() == R.id.registrationFragment) {
+                viewBinding.bottomNavigation.setVisibility(View.GONE);
             } else {
+                viewBinding.bottomNavigation.setVisibility(View.VISIBLE);
                 getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
             }
         }));

--- a/app/src/main/java/it/units/borghisegreti/activities/MainActivity.java
+++ b/app/src/main/java/it/units/borghisegreti/activities/MainActivity.java
@@ -5,7 +5,6 @@ import androidx.navigation.ActionOnlyNavDirections;
 import androidx.navigation.NavController;
 import androidx.navigation.fragment.NavHostFragment;
 
-import android.graphics.Color;
 import android.os.Bundle;
 import android.view.View;
 import android.view.WindowManager;

--- a/app/src/main/java/it/units/borghisegreti/fragments/MapsFragment.java
+++ b/app/src/main/java/it/units/borghisegreti/fragments/MapsFragment.java
@@ -193,44 +193,46 @@ public class MapsFragment extends Fragment implements OnMapReadyCallback, Google
     // when using MapView, we need to manually forward lifecycle stages
     @Override
     public void onStart() {
-        super.onStart();
         viewBinding.map.onStart();
+        super.onStart();
     }
 
     @Override
     public void onResume() {
-        super.onResume();
         viewBinding.map.onResume();
+        super.onResume();
     }
 
     @Override
     public void onPause() {
-        super.onPause();
         viewBinding.map.onPause();
+        super.onPause();
     }
 
     @Override
     public void onStop() {
-        super.onStop();
         viewBinding.map.onStop();
+        super.onStop();
     }
 
     @Override
-    public void onDestroy() {
-        super.onDestroy();
+    public void onDestroyView() {
         viewBinding.map.onDestroy();
         viewBinding = null;
+        super.onDestroyView();
     }
 
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
-        if (mapViewModel != null) {
+        if (mapViewModel != null && map != null) {
             mapViewModel.saveCameraLatitude(map.getCameraPosition().target.latitude);
             mapViewModel.saveCameraLongitude(map.getCameraPosition().target.longitude);
             mapViewModel.saveCameraZoom(map.getCameraPosition().zoom);
         }
         super.onSaveInstanceState(outState);
-        viewBinding.map.onSaveInstanceState(outState);
+        if (viewBinding != null) {
+            viewBinding.map.onSaveInstanceState(outState);
+        }
     }
 
     @Override


### PR DESCRIPTION
Solving #49, bug was caused by incorrect forwarding of lifecycle methods to the underlying `MapView`. As specified [here](https://developer.android.com/topic/libraries/view-binding#fragments), the view binding must be cleared in `onDestroyView()`, however this may cause some problems when binding is used in later stages. For example, the `onSaveInstanceState()` method is guaranteed to be called after `onDestroy()`, but there's no such guarantee with the `onDestroyView()` method.